### PR TITLE
Fix errors when importing from Shlink >=4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [5.3.1] - 2024-03-28
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Fix errors when importing short URLs using Shlink strategy from a Shlink 4 instance
+
+
 ## [5.3.0] - 2024-03-03
 ### Added
 * *Nothing*

--- a/src/Sources/Shlink/ShlinkImporter.php
+++ b/src/Sources/Shlink/ShlinkImporter.php
@@ -106,7 +106,7 @@ class ShlinkImporter implements ImporterStrategyInterface
             // reverse them.
             // In order to do that, we calculate the amount of pages we will get, and start from last to first.
             // Then, each page's result set gets reversed individually.
-            $visitsCount = $url['visitsCount'];
+            $visitsCount = $url['visitsCount'] ?? $url['visitsSummary']['total'];
             $expectedPages = (int) ceil($visitsCount / self::VISITS_PER_PAGE);
 
             return $this->mapper->mapShortUrl(
@@ -176,8 +176,9 @@ class ShlinkImporter implements ImporterStrategyInterface
             $url,
             ['X-Api-Key' => $params->apiKey, 'Accept' => 'application/json'],
         );
+        $visits = $parsedBody['visits'] ?? [];
 
-        return (int) ($parsedBody['visits']['orphanVisitsCount'] ?? 0);
+        return (int) ($visits['orphanVisitsCount'] ?? $visits['orphanVisits']['total'] ?? 0);
     }
 
     private function loadOrphanVisits(ShlinkParams $params, int $page): iterable

--- a/src/Sources/Shlink/ShlinkMapper.php
+++ b/src/Sources/Shlink/ShlinkMapper.php
@@ -32,7 +32,7 @@ final class ShlinkMapper implements ShlinkMapperInterface
             $url['shortCode'],
             $url['title'] ?? null,
             $visits,
-            $url['visitsCount'],
+            $url['visitsCount'] ?? $url['visitsSummary']['total'],
             $meta,
         );
     }

--- a/test/Sources/Shlink/ShlinkImporterTest.php
+++ b/test/Sources/Shlink/ShlinkImporterTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -58,7 +59,9 @@ class ShlinkImporterTest extends TestCase
             'shortUrl' => 'https://acel.me/rY9zd',
             'longUrl' => 'https://www.alejandrocelaya.com/foo',
             'dateCreated' => '2016-05-02T17:49:53+02:00',
-            'visitsCount' => 48,
+            'visitsSummary' => [
+                'total' => 48,
+            ],
             'tags' => ['bar', 'foo', 'website'],
             'meta' => [
                 'validUntil' => '2020-05-02T17:49:53+02:00',
@@ -216,7 +219,9 @@ class ShlinkImporterTest extends TestCase
     }
 
     #[Test]
-    public function orphanVisitsAreImportedWhenRequested(): void
+    #[TestWith([['orphanVisitsCount' => 800]])]
+    #[TestWith([['orphanVisits' => ['total' => 800]]])]
+    public function orphanVisitsAreImportedWhenRequested(array $visitsOverview): void
     {
         $visit1 = [
             'referer' => 'visit1',
@@ -244,11 +249,9 @@ class ShlinkImporterTest extends TestCase
         ];
 
         $this->apiConsumer->expects($this->exactly(4))->method('callApi')->willReturnCallback(
-            function (string $url) use ($visit1, $visit2) {
+            function (string $url) use ($visit1, $visit2, $visitsOverview) {
                 if (! str_contains($url, 'orphan')) {
-                    return [
-                        'visits' => ['orphanVisitsCount' => 800],
-                    ];
+                    return ['visits' => $visitsOverview];
                 }
 
                 return [


### PR DESCRIPTION
Shlink 4 has slightly changed the payload for some endpoints. This PR ensures the appropriate properties are checked to continue supporting both Shlink 4 and 3