### PR TITLE
Fix importing URLs with custom slugs from bitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [5.3.2] - 2024-04-12
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Take into consideration `custom_bitlinks` when consuming Bitly API.
+
+  When custom slugs are used, they are returned there, while the `link` field contains an internal random link which is not the one you want to import.
+
+
 ## [5.3.1] - 2024-03-28
 ### Added
 * *Nothing*

--- a/src/Sources/Bitly/BitlyApiImporter.php
+++ b/src/Sources/Bitly/BitlyApiImporter.php
@@ -108,7 +108,7 @@ class BitlyApiImporter implements ImporterStrategyInterface
                 $date = $hasCreatedDate && $params->keepCreationDate
                     ? DateHelper::dateFromAtom($link['created_at'])
                     : clone $progressTracker->startDate();
-                $parsedLink = $this->parseLink($link['link'] ?? '');
+                $parsedLink = $this->parseLink($link['custom_bitlinks'][0] ?? $link['link'] ?? '');
                 $host = $parsedLink['host'] ?? null;
                 $domain = $host !== 'bit.ly' && $params->importCustomDomains ? $host : null;
                 $shortCode = ltrim($parsedLink['path'] ?? '', '/');

--- a/test/Sources/Bitly/BitlyApiImporterTest.php
+++ b/test/Sources/Bitly/BitlyApiImporterTest.php
@@ -71,6 +71,7 @@ class BitlyApiImporterTest extends TestCase
                             [
                                 'created_at' => '2020-04-01T00:00:00+0000',
                                 'link' => 'http://customdom.com/ddd',
+                                'custom_bitlinks' => [],
                                 'long_url' => 'https://github.com',
                                 'tags' => ['bar'],
                             ],
@@ -90,7 +91,8 @@ class BitlyApiImporterTest extends TestCase
                         ],
                         [
                             'created_at' => '2020-02-01T00:00:00+0000',
-                            'link' => 'http://bit.ly/bbb',
+                            'link' => 'http://bit.ly/this_should_be_ignored',
+                            'custom_bitlinks' => ['http://bit.ly/bbb'],
                             'long_url' => 'https://github.com',
                             'tags' => ['foo', 'bar'],
                         ],


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2095

Bitly's API returns the URLs with the custom slug in the `custom_bitlinks`, while the `link` field contains a randomly generated path.

This PR makes sure we try to read the first entry from `custom_bitlinks`, and fall back to `link` when not set.