### PR TITLE
Set empty string as escape character for CSVs to avoid deprecation warnings in PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Changed
 * Update dependencies.
+* Set empty string as escape character for CSVs to avoid deprecation warnings in PHP 8.4
 
 ### Deprecated
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "guzzlehttp/guzzle": "^7.9",
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-phpunit": "^1.4",
-        "phpunit/phpunit": "^11.2",
+        "phpunit/phpunit": "^11.3",
         "psr/http-factory": "^1.1",
         "roave/security-advisories": "dev-master",
         "shlinkio/php-coding-standard": "~2.3.0",
@@ -53,7 +53,7 @@
         "cs": "phpcs",
         "cs:fix": "phpcbf",
         "stan": "phpstan analyse",
-        "test": "phpunit --order-by=random --testdox --colors=always",
+        "test": "phpunit --order-by=random --testdox --testdox-summary",
         "test:ci": "@test --coverage-clover=build/clover.xml",
         "test:pretty": "@test --coverage-html=build/coverage-html"
     },

--- a/src/Sources/Csv/CsvImporter.php
+++ b/src/Sources/Csv/CsvImporter.php
@@ -49,6 +49,10 @@ class CsvImporter implements ImporterStrategyInterface
         $csvReader = Reader::createFromStream($params->stream)->setDelimiter($params->delimiter)
                                                               ->setHeaderOffset(0);
 
+        // FIXME Workaround for PHP 8.4 deprecation warnings. To remove with league/csv 10
+        //       See https://github.com/thephpleague/csv/issues/532 for details
+        $csvReader->setEscape('');
+
         foreach ($csvReader as $record) {
             $record = $this->remapRecordHeaders($record);
             [$shortCode, $domain] = $this->parseShortCodeAndDomain($record);


### PR DESCRIPTION
See https://github.com/thephpleague/csv/issues/532