### PR TITLE
Remove dependency in ext-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ### Removed
 * Drop support for shlink-config 3.0
 * Drop support for PHP 8.3
+* Remove explicit dependency in `ext-json`, since it's part of PHP since v8.0
 
 ### Fixed
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": "^8.4",
-        "ext-json": "*",
         "laminas/laminas-servicemanager": "^4.5 || ^3.24",
         "league/csv": "^9.27",
         "shlinkio/shlink-config": "^4.0",


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2565

Remove explicit dependency in `ext-json`, since it's part of PHP since v8.0